### PR TITLE
Set default Speaker Box Size based on Tab Resolution (#23)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,6 @@ jobs:
 
       - name: Lint standard
         run: make lint
+
+      - name: Compile
+        run: make compile

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,8 @@ lint-fix: docker-build
 		-v "$(ROOT_DIR)/app:/code/app" \
 		spatial-volume-controller \
 		npm run lint-fix
+
+compile: docker-build
+	docker run --rm \
+		spatial-volume-controller \
+		npm run compile

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ https://standardjs.com/rules-ja.html
 make lint
 ```
 
+### トランスパイルテスト
+`tsc`を実行する。
+
+
+```sh
+make compile
+```
+
 #### 自動修正
 ```sh
 make lint-fix

--- a/app/scripts/background.ts
+++ b/app/scripts/background.ts
@@ -51,10 +51,15 @@ function captureActiveTab (tabId: number, tabTitle: string): void {
     streamSource.connect(gainNode)
     gainNode.connect(audioContext.destination)
 
+    const videoStream = stream.getVideoTracks()[0] ?? null
+    const videoStreamSettings = videoStream.getSettings()
+
     // container作成
     const container: AudioContainer = {
       tabId: tabId,
       tabTitle: tabTitle,
+      tabWidth: videoStreamSettings.width ?? 0,
+      tabHeight: videoStreamSettings.height ?? 0,
       audioContext: audioContext,
       streamSource: streamSource,
       gainNode: gainNode
@@ -63,7 +68,7 @@ function captureActiveTab (tabId: number, tabTitle: string): void {
     audioContainer.set(tabId, container)
 
     videoStreams.set(tabId, stream)
-    console.log(videoStreams.size)
+    console.log(`Current Tracking Tab Num: ${videoStreams.size}`)
     // console.error(`tracked ${tabId}`)
 
     // chrome.tabs.create({ url: chrome.extension.getURL('pages/index.html') })
@@ -196,7 +201,9 @@ chrome.runtime.onMessage.addListener((request: any, sender, sendResponse) => {
 
       const tabInfo: TabInfo = {
         id: cont.tabId,
-        title: cont.tabTitle
+        title: cont.tabTitle,
+        width: cont.tabWidth,
+        height: cont.tabHeight
       }
 
       tabs.push(tabInfo)

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -161,7 +161,7 @@ function _initScreen (): void {
   getTabs((response: TabsResponse) => {
     const tabs: TabInfo[] = response.tabs
     for (var i = 0; i < tabs.length; i++) {
-      const speakerIcon = _createSpeakerIcon(300, 100, `${tabs[i].id}`, tabs[i].title)
+      const speakerIcon = _createSpeakerIcon(300, 100, `${tabs[i].id}`, tabs[i].title, tabs[i].width, tabs[i].height)
       document.body.appendChild(speakerIcon)
 
       const videoElement = document.createElement('video')
@@ -213,13 +213,21 @@ function _createListenerIcon (left: number, top: number): HTMLElement {
   return dom
 }
 
-function _createSpeakerIcon (left: number, top: number, id: string, text: string): HTMLElement {
+function _createSpeakerIcon (left: number, top: number, id: string, text: string, baseWidth: number, baseHeight: number): HTMLElement {
   const dom: HTMLDivElement = document.createElement('div')
   dom.classList.add('speaker-box')
   dom.classList.add('drag-and-drop')
 
+  const maxDefaultHeight = 300 // TODO: calculate based on index tab resolution
+  const aspectRatio = baseWidth / baseHeight
+
+  const defaultHeight = Math.min(maxDefaultHeight, baseHeight)
+  const defaultWidth = aspectRatio * defaultHeight
+
   dom.style.left = `${left}px`
   dom.style.top = `${top}px`
+  dom.style.width = `${defaultWidth}px`
+  dom.style.height = `${defaultHeight}px`
 
   dom.dataset.id = id
   dom.dataset.text = text

--- a/app/scripts/interfaces/AudioContainer.ts
+++ b/app/scripts/interfaces/AudioContainer.ts
@@ -1,6 +1,8 @@
 export interface AudioContainer {
   tabId: number
   tabTitle: string
+  tabWidth: number
+  tabHeight: number
   audioContext: AudioContext
   streamSource: MediaStreamAudioSourceNode
   gainNode: GainNode

--- a/app/scripts/interfaces/TabInfo.ts
+++ b/app/scripts/interfaces/TabInfo.ts
@@ -1,4 +1,6 @@
 export interface TabInfo {
   id: number
   title: string
+  width: number
+  height: number
 }

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -23,10 +23,6 @@ img {
   display: flex;
   justify-content: center;
   align-items: center;
-
-  /* TODO: resizable from script */
-  width: 46vw;
-  height: 53vh;
 }
 
 .speaker-box video {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev:opera": "gulp --watch --vendor=opera",
     "dev:edge": "gulp --watch --vendor=edge",
     "lint": "ts-standard",
-    "lint-fix": "ts-standard --fix"
+    "lint-fix": "ts-standard --fix",
+    "compile": "tsc --noEmit"
   },
   "ts-standard": {
     "globals": [


### PR DESCRIPTION
#23 の修正

タブトラッキング開始時のタブ解像度に基づいてSpeakerBoxの初期サイズを決定する

タブ解像度のアスペクト比を維持して、デフォルトで最大高さ300pxを上限としている

高さ300pxは大きい(4K)ディスプレイだと小さすぎると思うので、拡張機能のindexページのタブ解像度と相対的に初期高さを決めるようにしたい（例えば高さの30%とか）

タブトラッキング中にトラッキング先のタブ解像度が変更された場合に対応もしたいけれど、これは権限を今後絞りたいという方向性的に難しいかもしれない

#40 を別PRで対応したいというのも考慮したい
